### PR TITLE
Make Sparkline Responsive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,31 +27,8 @@ import { Sparkline } from 'react-chartlet'
 const YourPage = () => (
   <Sparkline
     data={[2, 5, 3, 8, 1]}
-    width={200}
-    height={100}
+    height="100px"
   />
-)
-
-export default YourPage
-```
-
-### Responsive chart
-
-You can use the `Responsive` element to make your chart match the size of it's parent container. `Responsive` returns a function with it's own boundingClientRect object as a parameter; you can use this to set the width (or height) of the chart inside.
-
-Note that setting the height from the parent rect is only advisable if you're using a flex or grid layout.
-
-```js
-import { Responsive, Sparkline } from 'react-chartlet'
-
-const YourPage = () => (
-  <Responsive>
-    {({ width }) => <Sparkline
-      data={[2, 5, 3, 8, 1]}
-      width={width}
-      height={100}
-    />}
-  </Responsive>
 )
 
 export default YourPage
@@ -64,8 +41,8 @@ export default YourPage
 | Property | Type | Default | Description |
 | - | - | - | - |
 | data | array | `[]` | An array of numbers |
-| width | number | `200` | Width of your chart |
-| height | number | `100` | Height of your chart |
+| width | string | - | CSS width of your chart |
+| height | string | `100%` | CSS height of your chart |
 | min | number | smallest datapoint in `data` array | The minimum value on the y axis |
 | max | number | largest datapoint in `data` array | The maximum value on the y axis |
 | margin | number or object | `{ top: 5, bottom: 5 }` | Margin between the border of the chart and the line, either as a number to set all sides, or an object to set specific sides, like `{ top: 5, right: 5, bottom: 5, left: 5 }` |

--- a/src/charts/Sparkline.js
+++ b/src/charts/Sparkline.js
@@ -3,7 +3,7 @@ import Responsive from '../components/Responsive'
 
 const Sparkline = ({
   width,
-  height = 100,
+  height='100%',
   data = [],
   min,
   max,

--- a/src/charts/Sparkline.js
+++ b/src/charts/Sparkline.js
@@ -1,7 +1,8 @@
 import Line from '../components/Line'
+import Responsive from '../components/Responsive'
 
 const Sparkline = ({
-  width = 200,
+  width,
   height = 100,
   data = [],
   min,
@@ -13,23 +14,26 @@ const Sparkline = ({
   const marginFallback = typeof margin === 'number' ? margin : 0
 
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      {...props}
-    >
-      <Line
-        top={margin?.top ?? marginFallback}
-        left={margin?.left ?? marginFallback}
-        data={data}
-        width={width - (margin?.right ?? marginFallback)*2}
-        height={height - (margin?.bottom ?? marginFallback)*2}
-        min={min}
-        max={max}
-        style={lineStyle}
-      />
-    </svg>
+    <Responsive width={width} height={height}>
+      {({ width, height }) => <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        {...props}
+        style={{display: 'block', boxSizing: 'border-box', ...props.style}}
+      >
+        <Line
+          top={margin?.top ?? marginFallback}
+          left={margin?.left ?? marginFallback}
+          data={data}
+          width={width - (margin?.right ?? marginFallback)*2}
+          height={height - (margin?.bottom ?? marginFallback)*2}
+          min={min}
+          max={max}
+          style={lineStyle}
+        />
+      </svg>}
+    </Responsive>
   )
 }
 

--- a/src/charts/Sparkline.js
+++ b/src/charts/Sparkline.js
@@ -14,7 +14,7 @@ const Sparkline = ({
   const marginFallback = typeof margin === 'number' ? margin : 0
 
   return (
-    <Responsive width={width} height={height}>
+    <Responsive style={{width, height}}>
       {({ width, height }) => <svg
         width={width}
         height={height}

--- a/src/components/Responsive.js
+++ b/src/components/Responsive.js
@@ -2,11 +2,13 @@ import { useState } from 'react'
 import useResize from '../hooks/useResize'
 
 const Responsive = ({ children, ...props }) => {
-  const [rect, setRect] = useState({})
+  const [rect, setRect] = useState({ width: 0, height: 0 })
 
   const ref = useResize(el => setRect(el.getBoundingClientRect()))
 
-  return <div ref={ref} {...props}>{children(rect)}</div>
+  return <div ref={ref} {...props}>
+    {children(rect)}
+  </div>
 }
 
 export default Responsive

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,1 @@
 export { default as Sparkline } from './charts/Sparkline'
-
-export { default as Responsive } from './components/Responsive'

--- a/stories/Sparkline.stories.js
+++ b/stories/Sparkline.stories.js
@@ -1,4 +1,4 @@
-import { Sparkline, Responsive } from '../src'
+import { Sparkline } from '../src'
 
 export default { component: Sparkline }
 
@@ -9,15 +9,6 @@ const generateData = (length = 20) => Array.from({length}, () => Math.floor(Math
 export const Unstyled = Template.bind({})
 Unstyled.args = {
   data: generateData(),
-}
-
-export const AutoWidth = args => (
-  <Responsive>
-    {({ width }) => <Sparkline width={width} {...args} />}
-  </Responsive>
-)
-AutoWidth.args = {
-  data: generateData(50),
 }
 
 export const Styled = Template.bind({})

--- a/stories/Sparkline.stories.js
+++ b/stories/Sparkline.stories.js
@@ -9,10 +9,18 @@ const generateData = (length = 20) => Array.from({length}, () => Math.floor(Math
 export const Unstyled = Template.bind({})
 Unstyled.args = {
   data: generateData(),
+  height: 100,
 }
 
-export const FixedSize = Template.bind({})
-FixedSize.args = {
+export const FillContainer = args => <div style={{ width: '50%', height: '50px', margin: 'auto' }}>
+  <Sparkline {...args} />
+</div>
+FillContainer.args = {
+  data: generateData(),
+}
+
+export const FixedWidth = Template.bind({})
+FixedWidth.args = {
   data: generateData(),
   width: 500,
   height: 50,
@@ -35,5 +43,6 @@ Styled.args = {
 
 export const FlatLine = Template.bind({})
 FlatLine.args = {
-  data: [1]
+  data: [1],
+  height: 100
 }

--- a/stories/Sparkline.stories.js
+++ b/stories/Sparkline.stories.js
@@ -11,6 +11,13 @@ Unstyled.args = {
   data: generateData(),
 }
 
+export const FixedSize = Template.bind({})
+FixedSize.args = {
+  data: generateData(),
+  width: 500,
+  height: 50,
+}
+
 export const Styled = Template.bind({})
 Styled.args = {
   data: generateData(),


### PR DESCRIPTION
Ensure charts fill the available space of their container by default. Can be overriden by setting width and height. This removes the need to use the `Responsive` component.