### PR TITLE
Fix chart causing reflow of parent container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Chartlet
 ![npm version](https://img.shields.io/npm/v/react-chartlet)
-![minified size](https://img.shields.io/badge/minified%20size-680%20B-blue)
+![minified size](https://img.shields.io/badge/minified%20size-704%20B-blue)
 
 A dead simple and tiny React charting library
 
@@ -18,6 +18,8 @@ yarn add react-chartlet
 - [ ] Line
 
 ## Examples
+
+Please note that all charts are responsive by default; they will grow to fill the width of their container, and have height set to `100%`. You can set a specific size on them, however if you don't your chart may not show up due to it's height being 0.
 
 ### Sparkline
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Chartlet
 ![npm version](https://img.shields.io/npm/v/react-chartlet)
-![minified size](https://img.shields.io/badge/minified%20size-704%20B-blue)
+![minified size](https://img.shields.io/badge/minified%20size-730%20B-blue)
 
 A dead simple and tiny React charting library
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chartlet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A dead simple and tiny charting library for React",
   "source": "src/index.js",
   "main": "dist/main.js",

--- a/src/charts/Sparkline.js
+++ b/src/charts/Sparkline.js
@@ -3,7 +3,7 @@ import Responsive from '../components/Responsive'
 
 const Sparkline = ({
   width,
-  height='100%',
+  height = '100%',
   data = [],
   min,
   max,
@@ -14,13 +14,19 @@ const Sparkline = ({
   const marginFallback = typeof margin === 'number' ? margin : 0
 
   return (
-    <Responsive style={{width, height}}>
+    <Responsive style={{ width, height }}>
       {({ width, height }) => <svg
         width={width}
         height={height}
         viewBox={`0 0 ${width} ${height}`}
         {...props}
-        style={{display: 'block', boxSizing: 'border-box', ...props.style}}
+        style={{
+          display: 'block',
+          boxSizing: 'border-box',
+          position: 'absolute',
+          inset: 0,
+          ...props.style
+        }}
       >
         <Line
           top={margin?.top ?? marginFallback}

--- a/src/charts/Sparkline.js
+++ b/src/charts/Sparkline.js
@@ -1,5 +1,6 @@
 import Line from '../components/Line'
 import Responsive from '../components/Responsive'
+import ChartSvg from '../components/ChartSvg'
 
 const Sparkline = ({
   width,
@@ -15,30 +16,20 @@ const Sparkline = ({
 
   return (
     <Responsive style={{ width, height }}>
-      {({ width, height }) => <svg
-        width={width}
-        height={height}
-        viewBox={`0 0 ${width} ${height}`}
-        {...props}
-        style={{
-          display: 'block',
-          boxSizing: 'border-box',
-          position: 'absolute',
-          inset: 0,
-          ...props.style
-        }}
-      >
-        <Line
-          top={margin?.top ?? marginFallback}
-          left={margin?.left ?? marginFallback}
-          data={data}
-          width={width - (margin?.right ?? marginFallback)*2}
-          height={height - (margin?.bottom ?? marginFallback)*2}
-          min={min}
-          max={max}
-          style={lineStyle}
-        />
-      </svg>}
+      {({ width: autoWidth, height: autoHeight }) => (
+        <ChartSvg width={autoWidth} height={autoHeight} {...props} >
+          <Line
+            top={margin?.top ?? marginFallback}
+            left={margin?.left ?? marginFallback}
+            data={data}
+            width={autoWidth - (margin?.right ?? marginFallback)*2}
+            height={autoHeight - (margin?.bottom ?? marginFallback)*2}
+            min={min}
+            max={max}
+            style={lineStyle}
+          />
+        </ChartSvg>
+      )}
     </Responsive>
   )
 }

--- a/src/components/ChartSvg.js
+++ b/src/components/ChartSvg.js
@@ -1,0 +1,21 @@
+const ChartSvg = ({
+  width,
+  height,
+  ...props
+}) => (
+  <svg
+    width={width}
+    height={height}
+    viewBox={`0 0 ${width} ${height}`}
+    {...props}
+    style={{
+      display: 'block',
+      boxSizing: 'border-box',
+      position: 'absolute',
+      inset: 0,
+      ...props.style
+    }}
+  />
+)
+
+export default ChartSvg

--- a/src/components/Responsive.js
+++ b/src/components/Responsive.js
@@ -6,7 +6,10 @@ const Responsive = ({ children, ...props }) => {
 
   const ref = useResize(el => setRect(el.getBoundingClientRect()))
 
-  return <div ref={ref} {...props}>
+  return <div ref={ref} {...props} style={{
+    position: 'relative',
+    ...props.style
+  }}>
     {children(rect)}
   </div>
 }


### PR DESCRIPTION
The chart svg was previously a block element, which affected the size of the container and caused it to reflow if the chart changed size. I've made the chart an absolute element which always takes up 100% of it's parent so it can't affect the flow.